### PR TITLE
#10 version up dart_ping

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   cupertino_icons: ^1.0.2
 
   lan_scanner:
-    path: C:\Users\hjozw\OneDrive\Dokumenty\Development\Flutter\lan_scanner
+    path: ../
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/lan_scanner.dart
+++ b/lib/src/lan_scanner.dart
@@ -48,7 +48,8 @@ class LanScanner {
       final Ping pingRequest;
 
       try {
-        pingRequest = Ping(hostToPing, count: 1, timeout: timeout);
+        pingRequest =
+            Ping(hostToPing, count: 1, timeout: timeout, forceCodepage: true);
       } catch (exc) {
         if (exc is UnimplementedError &&
             (exc.message?.contains('iOS') ?? false)) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  dart_ping: ^7.0.1
+  dart_ping: ^9.0.0
 
 dev_dependencies:
   dart_code_metrics: ^4.16.0


### PR DESCRIPTION
# Issue
- #10

# Description
I investigated [this issue](https://github.com/ivirtex/lan_scanner/issues/10), then i discover this problem occur from dart_ping.
So, i post [an issue](https://github.com/point-source/dart_ping/issues/51) and was fixed this problem.

This pullrequest is for version up of dart_ping and added neccesary an arg.

```dart
Ping(hostToPing, count: 1, timeout: timeout, forceCodepage: true); // added [forceCodepage: true]
```
```forceCodepage``` is an arg for out of English language.
When this arg is true, call a ping command with ```chcp 437```.
So I think it's fine for this argument to always be true!

I'm Japanese, so i am not good at writing English.
Sorry for if hard to read...
